### PR TITLE
CURRENTLY BROKEN: WIP Support for Children/Block Helpers

### DIFF
--- a/lib/BlazeToReact-client.jsx
+++ b/lib/BlazeToReact-client.jsx
@@ -1,3 +1,9 @@
+const Passthrough = React.createClass({
+    render() {
+        return this.props.elements;
+    }
+})
+
 BlazeToReact = function(name) {
   return React.createClass({
     shouldComponentUpdate() {
@@ -7,7 +13,12 @@ BlazeToReact = function(name) {
 
     componentDidMount() {
       let el = React.findDOMNode(this);
-      this.blazeView = Blaze.renderWithData(Template[name], this.props, el);
+      this.blazeView = Blaze.renderWithData(Template['BlazeToReactHelper'], {
+          template: name,
+          data: _.omit(this.props, 'children'),
+          component: Passthrough,
+          elements: this.props.children
+      }, el);
     },
 
     componentWillUnmount() {

--- a/lib/BlazeToReact-helper.html
+++ b/lib/BlazeToReact-helper.html
@@ -1,0 +1,5 @@
+<template name="BlazeToReactHelper">
+  {{# Template.dynamic template=template data=data }}
+    {{> React component=component elements=elements }}
+  {{/ Template.dynamic }}
+</template>

--- a/package.js
+++ b/package.js
@@ -9,8 +9,10 @@ Package.describe({
 Package.onUse(function(api) {
   api.use(['react@0.1.0']);
   api.use(['blaze@2.1.0'], 'client');
+  api.use(['templating@1.1.1'], 'client');
 
   api.add_files(['lib/BlazeToReact-client.jsx'], ['client']);
+  api.add_files(['lib/BlazeToReact-helper.html'], ['client']);
   api.add_files(['lib/BlazeToReact-server.jsx'], ['server']);
 
   api.export('BlazeToReact');


### PR DESCRIPTION
This is slightly convoluted, but basically it passes a call to the MDG's `{{> React}}` to the provided template (currently, it doesn't actually have any way of knowing if the passed template is a block helper, but if it isn't the passed "children" will probably be ignored).