### PR TITLE
Bumped React version to 15.0.1 for Meteor 1.3.

### DIFF
--- a/.versions
+++ b/.versions
@@ -20,11 +20,11 @@ mongo-id@1.0.1
 observe-sequence@1.0.7
 promise@0.5.1
 random@1.0.5
-react@0.14.1
+react@15.0.1
 react-meteor-data@0.2.2
-react-runtime@0.14.1
-react-runtime-dev@0.14.1
-react-runtime-prod@0.14.1
+react-runtime@15.0.1
+react-runtime-dev@15.0.1
+react-runtime-prod@15.0.1
 reactive-var@1.0.6
 thereactivestack:blazetoreact@0.1.5
 tracker@1.0.9

--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use(['react@0.14.1']);
+  api.use(['react@15.0.1']);
   api.use(['blaze@2.1.0'], 'client');
 
   api.add_files(['lib/BlazeToReact-client.jsx'], ['client']);


### PR DESCRIPTION
Bumped the React version to 15.0.1 for use with Meteor 1.3.1. It works for my own project as far as I can tell. It is not clear to me whether react-runtime is utilized by BlazeToReact, which would cause problems as described [here](https://voice.kadira.io/getting-started-with-meteor-1-3-and-react-15e071e41cd1#.v8f2lmxuw).

Addresses issue #12 